### PR TITLE
fix(metadata): 优化 ffprobe 远程探测并添加 Range 回退

### DIFF
--- a/internal/httputil/read_seeker.go
+++ b/internal/httputil/read_seeker.go
@@ -155,7 +155,18 @@ func setHeaders(req *http.Request, headers map[string]string) {
 	}
 }
 
+// fetchContentLength 获取远程文件总大小。
+// 优先 HEAD；部分服务器不路由 HEAD（404/405， 仅注册
+// GET/POST）或不回 Content-Length，此时回退 GET + Range: bytes=0-0 探测——
+// 两条路径都只读响应头、不下载文件内容。
 func fetchContentLength(client *http.Client, url string, headers map[string]string) (int64, error) {
+	if size, err := fetchContentLengthByHead(client, url, headers); err == nil {
+		return size, nil
+	}
+	return fetchContentLengthByRange(client, url, headers)
+}
+
+func fetchContentLengthByHead(client *http.Client, url string, headers map[string]string) (int64, error) {
 	req, err := http.NewRequest(http.MethodHead, url, nil)
 	if err != nil {
 		return 0, fmt.Errorf("HEAD request failed: %w", err)
@@ -182,6 +193,47 @@ func fetchContentLength(client *http.Client, url string, headers map[string]stri
 		return 0, fmt.Errorf("invalid Content-Length %q: %w", cl, err)
 	}
 	return size, nil
+}
+
+// fetchContentLengthByRange HEAD 不可用时的兜底：GET + Range: bytes=0-0。
+// - 206：从 Content-Range「bytes 0-0/total」解析总大小；
+// - 416：部分服务器以「bytes */total」回告总大小，同样可解析；
+// - 200：服务器忽略 Range 返回全量，Content-Length 即总大小
+//   （响应头已到手，body 不读取直接断开，不会拉取文件内容）。
+func fetchContentLengthByRange(client *http.Client, url string, headers map[string]string) (int64, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("range probe request failed: %w", err)
+	}
+	setHeaders(req, headers)
+	req.Header.Set("Range", "bytes=0-0")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("range probe request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusPartialContent, http.StatusRequestedRangeNotSatisfiable:
+		if total := parseContentRangeTotal(resp.Header.Get("Content-Range")); total > 0 {
+			return total, nil
+		}
+		return 0, fmt.Errorf("range probe: status %d without parsable total (Content-Range %q)",
+			resp.StatusCode, resp.Header.Get("Content-Range"))
+	case http.StatusOK:
+		cl := resp.Header.Get("Content-Length")
+		if cl == "" {
+			return 0, fmt.Errorf("range probe: 200 without Content-Length")
+		}
+		size, err := strconv.ParseInt(cl, 10, 64)
+		if err != nil || size <= 0 {
+			return 0, fmt.Errorf("range probe: invalid Content-Length %q", cl)
+		}
+		return size, nil
+	default:
+		return 0, fmt.Errorf("range probe returned status %d", resp.StatusCode)
+	}
 }
 
 func fetchRange(client *http.Client, url string, start, end int64, headers map[string]string) ([]byte, error) {

--- a/internal/httputil/read_seeker_test.go
+++ b/internal/httputil/read_seeker_test.go
@@ -1,0 +1,163 @@
+package httputil
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// HEAD 支持的服务器：走 HEAD 路径拿大小，GET 不应被触发（行为与旧版完全一致）。
+func TestFetchContentLengthHeadSupported(t *testing.T) {
+	getCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", "1234")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			getCalled = true
+			w.WriteHeader(http.StatusTeapot)
+		}
+	}))
+	defer srv.Close()
+
+	size, err := fetchContentLength(srv.Client(), srv.URL, nil)
+	if err != nil {
+		t.Fatalf("fetchContentLength() error = %v", err)
+	}
+	if size != 1234 {
+		t.Fatalf("size = %d, want 1234", size)
+	}
+	if getCalled {
+		t.Fatal("GET should not be called when HEAD works")
+	}
+}
+
+// HEAD 404（仅注册 GET/POST）→ 回退 Range 0-0 →
+// 206 + Content-Range 解析总大小。
+func TestFetchContentLengthHead404FallsBackToRange(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead:
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodGet && r.Header.Get("Range") == "bytes=0-0":
+			w.Header().Set("Content-Range", "bytes 0-0/61520341")
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte("x"))
+		default:
+			w.WriteHeader(http.StatusTeapot)
+		}
+	}))
+	defer srv.Close()
+
+	size, err := fetchContentLength(srv.Client(), srv.URL, nil)
+	if err != nil {
+		t.Fatalf("fetchContentLength() error = %v", err)
+	}
+	if size != 61520341 {
+		t.Fatalf("size = %d, want 61520341", size)
+	}
+}
+
+// HEAD 405 + 416（Content-Range 以「bytes */total」回告总大小）。
+func TestFetchContentLengthFallsBackTo416Total(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		case r.Method == http.MethodGet:
+			w.Header().Set("Content-Range", "bytes */777")
+			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+		}
+	}))
+	defer srv.Close()
+
+	size, err := fetchContentLength(srv.Client(), srv.URL, nil)
+	if err != nil {
+		t.Fatalf("fetchContentLength() error = %v", err)
+	}
+	if size != 777 {
+		t.Fatalf("size = %d, want 777", size)
+	}
+}
+
+// 服务器忽略 Range 返回 200 全量 → 直接取 Content-Length。
+func TestFetchContentLengthFallsBackWhenRangeIgnored(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.WriteHeader(http.StatusNotFound)
+		case http.MethodGet:
+			w.Header().Set("Content-Length", "999")
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	size, err := fetchContentLength(srv.Client(), srv.URL, nil)
+	if err != nil {
+		t.Fatalf("fetchContentLength() error = %v", err)
+	}
+	if size != 999 {
+		t.Fatalf("size = %d, want 999", size)
+	}
+}
+
+// 两条探测路径都失败：错误应上抛（与旧行为一致）。
+func TestFetchContentLengthBothProbesFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	if _, err := fetchContentLength(srv.Client(), srv.URL, nil); err == nil {
+		t.Fatal("expected error when both HEAD and range probe fail")
+	}
+}
+
+// 端到端：对「无 HEAD 路由、支持 Range」的服务器，HTTPReadSeeker
+// 应回退成功并正确读出头部/尾部数据。
+func TestHTTPReadSeekerWorksWithoutHead(t *testing.T) {
+	payload := bytes.Repeat([]byte{0}, 300*1024)
+	payload[0], payload[1], payload[2] = 'A', 'B', 'C'
+	payload[len(payload)-1] = 'Z'
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusNotFound) // 模拟 无 HEAD 路由
+			return
+		}
+		http.ServeContent(w, r, "audio.mp3", time.Time{}, bytes.NewReader(payload))
+	}))
+	defer srv.Close()
+
+	rs, err := NewHTTPReadSeekerWithHeaders(srv.Client(), srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewHTTPReadSeekerWithHeaders() error = %v", err)
+	}
+	if got := rs.Size(); got != int64(len(payload)) {
+		t.Fatalf("Size() = %d, want %d", got, len(payload))
+	}
+
+	head := make([]byte, 3)
+	if _, err := io.ReadFull(rs, head); err != nil {
+		t.Fatalf("read head: %v", err)
+	}
+	if string(head) != "ABC" {
+		t.Fatalf("head = %q, want %q", head, "ABC")
+	}
+
+	if _, err := rs.Seek(-1, io.SeekEnd); err != nil {
+		t.Fatalf("seek: %v", err)
+	}
+	tail := make([]byte, 1)
+	if _, err := io.ReadFull(rs, tail); err != nil {
+		t.Fatalf("read tail: %v", err)
+	}
+	if tail[0] != 'Z' {
+		t.Fatalf("tail = %q, want %q", tail, "Z")
+	}
+}

--- a/internal/services/metadata.go
+++ b/internal/services/metadata.go
@@ -608,12 +608,55 @@ func (m *MetadataExtractor) probeWithTagLib(ctx context.Context, rawURL string, 
 }
 
 // probeWithFFProbe 通过 ffprobe 补充缺失的元数据字段。
+//
+// 默认给 ffprobe 注入开放区间「Range: bytes=0-」请求头：
+//   - 支持 Range 的源（embed=1 直链）返回
+//     206 + 真实总大小（Content-Range），ffmpeg 按需读取 analyzeduration/probesize
+//     内的数据即退出，客户端断开使服务器侧传输终止——避免触发个别「无 Range 就
+//     整曲预下载再回吐」的代理端点把整曲拉进内存；同时 ffmpeg 获知可 seek，
+//     m4a 尾部 moov 可按 Range 跳读，元数据更完整；
+//   - 忽略 Range 返回 200 全量的源，行为与旧版一致（ffmpeg 读够即断开）。
+//
+// 极少数对 Range 处理异常（返回 4xx）的源：去掉注入头按旧行为重试一次。
 func (m *MetadataExtractor) probeWithFFProbe(ctx context.Context, rawURL string, headers map[string]string, result *RemoteProbeResult) error {
+	err := m.runFFProbeOnURL(ctx, rawURL, headers, result, true)
+	if err == nil {
+		return nil
+	}
+	if _, hasRange := headers["Range"]; hasRange {
+		// 调用方自带 Range 头，失败与注入无关，不重试
+		return err
+	}
+	slog.Debug("ffprobe with Range probe header failed, retrying without it", "url", rawURL, "error", err)
+	return m.runFFProbeOnURL(ctx, rawURL, headers, result, false)
+}
+
+// ffprobeHeaders 组装 ffprobe 的请求头：withRange 时注入开放区间
+// 「Range: bytes=0-」（复制后注入，不修改调用方传入的 map——同一 headers
+// 还会传给 taglib 阶段与重试路径）。调用方自带 Range 时不覆盖。
+func ffprobeHeaders(headers map[string]string, withRange bool) map[string]string {
+	if !withRange {
+		return headers
+	}
+	merged := make(map[string]string, len(headers)+1)
+	for k, v := range headers {
+		merged[k] = v
+	}
+	if _, ok := merged["Range"]; !ok {
+		merged["Range"] = "bytes=0-"
+	}
+	return merged
+}
+
+// runFFProbeOnURL 执行一次 ffprobe 远程探测；withRange 时注入「Range: bytes=0-」。
+// result 只在本次成功解析后才被更新，失败重试不会残留脏数据。
+func (m *MetadataExtractor) runFFProbeOnURL(ctx context.Context, rawURL string, headers map[string]string, result *RemoteProbeResult, withRange bool) error {
 	if m.config.FFProbePath == "" {
 		return fmt.Errorf("ffprobe not configured")
 	}
 	args := []string{"-v", "quiet", "-print_format", "json", "-show_format", "-show_streams", "-analyzeduration", "10000000"}
-	if h := httputil.FormatFFmpegHeaders(headers); h != "" {
+	probeHeaders := ffprobeHeaders(headers, withRange)
+	if h := httputil.FormatFFmpegHeaders(probeHeaders); h != "" {
 		args = append(args, "-headers", h)
 	}
 	args = append(args, rawURL)

--- a/internal/services/metadata_probe_range_test.go
+++ b/internal/services/metadata_probe_range_test.go
@@ -1,0 +1,159 @@
+package services
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+)
+
+func TestFFProbeHeadersRangeInjection(t *testing.T) {
+	t.Run("nil headers with injection", func(t *testing.T) {
+		got := ffprobeHeaders(nil, true)
+		if got["Range"] != "bytes=0-" {
+			t.Fatalf("Range = %q, want bytes=0-", got["Range"])
+		}
+	})
+
+	t.Run("inject without mutating caller map", func(t *testing.T) {
+		caller := map[string]string{"Authorization": "Bearer x"}
+		got := ffprobeHeaders(caller, true)
+		if got["Range"] != "bytes=0-" {
+			t.Fatalf("Range = %q, want bytes=0-", got["Range"])
+		}
+		if got["Authorization"] != "Bearer x" {
+			t.Fatalf("Authorization = %q, want Bearer x", got["Authorization"])
+		}
+		if len(caller) != 1 {
+			t.Fatalf("caller map mutated: %v", caller)
+		}
+		if _, ok := caller["Range"]; ok {
+			t.Fatal("caller map should not gain a Range key")
+		}
+	})
+
+	t.Run("caller provided Range is preserved", func(t *testing.T) {
+		caller := map[string]string{"Range": "bytes=100-"}
+		got := ffprobeHeaders(caller, true)
+		if got["Range"] != "bytes=100-" {
+			t.Fatalf("Range = %q, want caller's bytes=100-", got["Range"])
+		}
+	})
+
+	t.Run("no injection when disabled", func(t *testing.T) {
+		caller := map[string]string{"Authorization": "Bearer x"}
+		got := ffprobeHeaders(caller, false)
+		if got["Authorization"] != "Bearer x" {
+			t.Fatalf("Authorization = %q", got["Authorization"])
+		}
+		if _, ok := got["Range"]; ok {
+			t.Fatal("Range should not be injected when disabled")
+		}
+	})
+}
+
+// writeFakeFFProbe 写一个可执行的假 ffprobe：遍历参数，遇到含 needle 的参数
+// 即以 exitCode 退出；否则向 stdout 输出一份合法的 ffprobe JSON。
+func writeFakeFFProbe(t *testing.T, needle string, exitCode int, counterPath string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake ffprobe script test requires a unix shell")
+	}
+	script := `#!/bin/sh
+printf x >> ` + counterPath + `
+for arg in "$@"; do
+  case "$arg" in
+    *` + needle + `*) exit ` + strconv.Itoa(exitCode) + ` ;;
+  esac
+done
+cat <<'JSON'
+{"format":{"duration":"3.5","format_name":"mp3","bit_rate":"128000"},"streams":[{"codec_type":"audio","sample_rate":"44100"}]}
+JSON
+`
+	path := filepath.Join(t.TempDir(), "fake-ffprobe.sh")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake ffprobe: %v", err)
+	}
+	return path
+}
+
+// writeAlwaysFailFFProbe 写一个无条件失败（exit 1）的假 ffprobe。
+func writeAlwaysFailFFProbe(t *testing.T, counterPath string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake ffprobe script test requires a unix shell")
+	}
+	script := `#!/bin/sh
+printf x >> ` + counterPath + `
+exit 1
+`
+	path := filepath.Join(t.TempDir(), "fake-ffprobe-fail.sh")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake ffprobe: %v", err)
+	}
+	return path
+}
+
+// countProbeInvocations 从计数文件读取探测执行次数（每次执行追加一个 x）。
+func countProbeInvocations(t *testing.T, counterPath string) int {
+	t.Helper()
+	data, err := os.ReadFile(counterPath)
+	if err != nil {
+		return 0
+	}
+	return len(string(data))
+}
+
+// 注入的 Range 头导致 ffprobe 失败时，自动去掉注入头重试并成功。
+func TestProbeWithFFProbeRetriesWithoutRange(t *testing.T) {
+	dir := t.TempDir()
+	counter := filepath.Join(dir, "probe-count")
+	scriptPath := writeFakeFFProbe(t, `"bytes=0-"`, 3, counter)
+
+	m := NewMetadataExtractor(&MetadataConfig{FFProbePath: scriptPath})
+
+	var result RemoteProbeResult
+	if err := m.probeWithFFProbe(context.Background(), "http://example.invalid/a.mp3", nil, &result); err != nil {
+		t.Fatalf("probeWithFFProbe() error = %v", err)
+	}
+
+	if result.Duration != 3.5 {
+		t.Fatalf("Duration = %v, want 3.5", result.Duration)
+	}
+	if result.Format != "mp3" {
+		t.Fatalf("Format = %q, want mp3", result.Format)
+	}
+	if result.BitRate != 128 {
+		t.Fatalf("BitRate = %v, want 128", result.BitRate)
+	}
+	if result.SampleRate != 44100 {
+		t.Fatalf("SampleRate = %v, want 44100", result.SampleRate)
+	}
+	if got := countProbeInvocations(t, counter); got != 2 {
+		t.Fatalf("ffprobe invocations = %d, want 2 (fail with Range, retry without)", got)
+	}
+}
+
+// 调用方自带 Range 头时失败不重试（失败与注入无关）。
+func TestProbeWithFFProbeNoRetryWhenCallerProvidesRange(t *testing.T) {
+	dir := t.TempDir()
+	counter := filepath.Join(dir, "probe-count")
+	scriptPath := writeAlwaysFailFFProbe(t, counter)
+
+	m := NewMetadataExtractor(&MetadataConfig{FFProbePath: scriptPath})
+
+	var result RemoteProbeResult
+	err := m.probeWithFFProbe(context.Background(), "http://example.invalid/a.mp3",
+		map[string]string{"Range": "bytes=0-100"}, &result)
+	if err == nil {
+		t.Fatal("expected error when caller Range probe fails")
+	}
+	if got := countProbeInvocations(t, counter); got != 1 {
+		t.Fatalf("ffprobe invocations = %d, want 1 (no retry when caller provides Range)", got)
+	}
+	if result.Duration != 0 || result.Format != "" {
+		t.Fatalf("result should stay untouched on failure, got %+v", result)
+	}
+}


### PR DESCRIPTION
注入开放区间 Range 头避免整曲预下载，支持 206/416/200 的长度解析；失败时自动回退无 Range 重试。